### PR TITLE
normalize docker's two /usr/local/bin entries

### DIFF
--- a/docker-verticapy/Dockerfile
+++ b/docker-verticapy/Dockerfile
@@ -16,4 +16,6 @@ COPY ./notebooks /project/notebooks
 
 EXPOSE 8888
 
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 ENTRYPOINT ["jupyter", "lab","--ip=0.0.0.0","--allow-root"]


### PR DESCRIPTION
Not sure why docker has two entries in the path by default.  This should
remove one of them and clean up the default path.