### PR TITLE
don't require both containers

### DIFF
--- a/bin/vertica-install
+++ b/bin/vertica-install
@@ -6,6 +6,7 @@
 # defaults that can be overridden with environment variables.
 : ${VERTICA_PORT:=${VSQL_PORT:-5433}}
 : ${SSHD_PORT:=5432}
+: ${VERTICALAB_CONTAINER_NAME:=verticalab}
 : ${VERTICA_CONTAINER_NAME:=vertica-demo}
 : ${VERTICA_HOST_NAME:=$VERTICA_CONTAINER_NAME}
 : ${DB_NAME:=demo}
@@ -90,6 +91,12 @@ docker exec -i "${VERTICA_ENV[@]}" $VERTICA_CONTAINER_NAME sudo bash -c 'echo "L
 
 # a temporary fix to allow restarts of the docker container
 docker exec -i "${VERTICA_ENV[@]}" $VERTICA_CONTAINER_NAME sed -i.bak 's/\(cp.*\)/\1 || true/' /opt/vertica/bin/docker-entrypoint.sh
+
+# if verticalab is running
+if docker exec -i "$VERTICALAB_CONTAINER_NAME" true 2>/dev/null; then
+  # copy dbadmin@vertica-demo credentials to root@verticapy-demo to enable ssh
+  docker exec -i "$VERTICA_CONTAINER_NAME" bash -c "cd; tar -zcf - .ssh" | docker exec -i "$VERTICALAB_CONTAINER_NAME" bash -c "cd; tar -zxf -"
+fi
 
 # create the database
 docker exec -i "${VERTICA_ENV[@]}" "$VERTICA_CONTAINER_NAME" opt/vertica/bin/admintools -t create_db --database="$DB_NAME" --password= --hosts=localhost || exit $?

--- a/bin/verticalab
+++ b/bin/verticalab
@@ -48,18 +48,16 @@ if [[ $FROM_HOME = true ]] ; then
     VOL_FLAG="-v $HOME:/project"
 fi
 
-# make sure vertica-demo is running
-if ! docker exec -i "$VERTICA_CONTAINER_NAME" true; then
-  echo "Cannot access $VERTICA_CONTAINER_NAME.  Did you run vertica-install?" >&2
-  exit 1
-fi
-
 docker run -d -it --rm -p $PORT:8888 $VOL_FLAG --name "$VERTICALAB_CONTAINER_NAME" "$DEMO_IMG" || exit $?
 
-# copy dbadmin@vertica-demo credentials to root@verticapy-demo to enable ssh
-docker exec -i "$VERTICA_CONTAINER_NAME" bash -c "cd; tar -zcf - .ssh" | docker exec -i "$VERTICALAB_CONTAINER_NAME" bash -c "cd; tar -zxf -"
+# if vertica-demo is running
+if docker exec -i "$VERTICA_CONTAINER_NAME" true 2>/dev/null; then
+  # copy dbadmin@vertica-demo credentials to root@verticapy-demo to enable ssh
+  docker exec -i "$VERTICA_CONTAINER_NAME" bash -c "cd; tar -zcf - .ssh" | docker exec -i "$VERTICALAB_CONTAINER_NAME" bash -c "cd; tar -zxf -"
+fi
+
 # tweak some settings to disable the fingerprint warnings
-docker exec -i "$VERTICALAB_CONTAINER_NAME" bash -c 'printf "%s\n" "Host '"$VERTICA_HOST_NAME"' '"$DOCKER_HOSTNAME"'" "    HostName '"$DOCKER_HOSTNAME"'" "    Port '"$VERTICA_SSH_PORT"'" "    User dbadmin" "    GlobalKnownHostsFile=/dev/nulls" "    UserKnownHostsFile=/dev/null" "    UpdateHostKeys=no" "    StrictHostKeyChecking=no" "    LogLevel=error" "    RequestTTY=yes" > $HOME/.ssh/config; chmod 600 $HOME/.ssh/config'
+docker exec -i "$VERTICALAB_CONTAINER_NAME" bash -c 'umask 077; mkdir -p $HOME/.ssh; printf "%s\n" "Host '"$VERTICA_HOST_NAME"' '"$DOCKER_HOSTNAME"'" "    HostName '"$DOCKER_HOSTNAME"'" "    Port '"$VERTICA_SSH_PORT"'" "    User dbadmin" "    GlobalKnownHostsFile=/dev/nulls" "    UserKnownHostsFile=/dev/null" "    UpdateHostKeys=no" "    StrictHostKeyChecking=no" "    LogLevel=error" "    RequestTTY=yes" > $HOME/.ssh/config'
 
 echo "Starting..."
 # sleep some time to wait for jupyterlab logs


### PR DESCRIPTION
in both vertica-install and verticalab, copy the dbadmin ssh credentials
over.  That way it doesn't matter which is started first.