### PR TITLE
Resolve pip broken permissions warning

### DIFF
--- a/docker-verticapy/Dockerfile
+++ b/docker-verticapy/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --upgrade pip \
     pip install -r requirements.txt \
     && rm requirements.txt \
     && apt-get -y install curl dirmngr apt-transport-https lsb-release ca-certificates \
-    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get -y install nodejs \
     && pip install /project/theme \
     && pip install /project/verticatools \


### PR DESCRIPTION
When building verticapy-jupyterlab image, we were getting the following: "WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv". So now we set up a virtualenv as recommended. 