### PR TITLE
If container exists but EULA not signed, reinstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ vertica-stop: ## Stop and delete the vertica container.
 .PHONY: vertica-start
 vertica-start: etc/vertica-demo.conf ## start/restart the vertica container.
 	@source etc/vertica-demo.conf; \
-	if (($$(docker ps -a --no-trunc -q -f NAME="$$VERTICA_CONTAINER_NAME" | wc -l)==0)); then \
+	if [[ -z $$VERTICA_EULA ]] || [[ -z $$(docker ps -a --no-trunc -q -f NAME="$$VERTICA_CONTAINER_NAME") ]]; then \
 	    $(MAKE) vertica-install; \
 	else \
 	    bin/vertica-start; \

--- a/bin/vertica-install
+++ b/bin/vertica-install
@@ -62,7 +62,8 @@ docker network create "$DOCKER_NETWORK" 2>/dev/null
 VERTICA_RUNARGS+=( --network "$DOCKER_NETWORK" )
 
 # clear out old container in case it had issues
-docker container rm $VERTICA_CONTAINER_NAME 2>/dev/null
+docker stop $VERTICA_CONTAINER_NAME >/dev/null 2>&1
+docker container rm $VERTICA_CONTAINER_NAME >/dev/null 2>&1
 
 docker run --detach "${VERTICA_RUNARGS[@]}" "${VERTICA_ENV[@]}" "$VERTICA_DOCKER_IMAGE" || abort $? "Could not create docker"
 


### PR DESCRIPTION
re-install vertica-demo if the container exists but the conf file doesn't indicate an EULA signature.  Before this fix, if someone erases their etc/vertica-demo.conf file because they wanted to start from scratch, it wouldn't clear out the old vertica-demo container.

closes #103