### PR TITLE
Update packages version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,8 @@ spark-stop:
 	cd docker-spark/docker && docker-compose stop
 
 .PHONY: spark-uninstall
-spark-uninstall:
-	cd docker-spark/docker && docker-compose down && \
+spark-uninstall: spark-stop
+	cd docker-spark/docker && docker-compose rm -f && \
 	docker image rm docker-spark && \
 	docker image rm docker-spark-worker && \
 	docker image rm mdouchement/hdfs  

--- a/docker-spark/docker/spark/Dockerfile
+++ b/docker-spark/docker/spark/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 # Sync Python version
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
-      "python-3.8.16-1-linux-${OS_ARCH}-debian-11" \
+      "python-3.9.16-1-linux-${OS_ARCH}-debian-11" \
     ) && \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \

--- a/docker-verticapy/Dockerfile
+++ b/docker-verticapy/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION="3.8-slim-buster"
+ARG PYTHON_VERSION="3.9-slim-buster"
 FROM python:${PYTHON_VERSION}
 
 ENV VIRTUAL_ENV=/opt/venv
@@ -38,7 +38,6 @@ RUN pip install --upgrade pip \
     && apt-get -y install nodejs \
     && pip install /project/theme \
     && pip install /project/verticatools \
-    && pip install /project/sql-editor \
     && pip install PySpark \
     && pip install PrettyTable \
     && rm -r /project/verticatools \
@@ -54,7 +53,7 @@ RUN pip install --upgrade pip \
     # && jupyter labextension install jupyterlab-chart-editor
 
 # Install Spark
-RUN wget https://dlcdn.apache.org/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz \
+RUN wget https://dlcdn.apache.org/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3.tgz \
     && tar xvf spark-3* \
     && rm spark-3*.tgz \
     && mv spark-3* /opt/ \

--- a/docker-verticapy/notebooks/spark/install-connector.sh
+++ b/docker-verticapy/notebooks/spark/install-connector.sh
@@ -6,5 +6,8 @@
 
 version=$(curl --silent "https://api.github.com/repos/vertica/spark-connector/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'| sed 's/v//g')
 
-mvn -U dependency:copy -Dartifact=com.vertica.spark:vertica-spark:$version -DoutputDirectory=/project/notebooks/spark 2> /dev/null
+echo "Installing..."
+echo
+mvn -U dependency:copy --quiet -Dartifact=com.vertica.spark:vertica-spark:$version -DoutputDirectory=/project/notebooks/spark 2> /dev/null && echo -e "\e[32mBUILD SUCCESS" || echo -e "\e[31mBUILD FAILURE"
 
+exit 0

--- a/etc/vertica-demo.conf.default
+++ b/etc/vertica-demo.conf.default
@@ -10,7 +10,7 @@ VERTICALAB_IMG=verticapy-jupyterlab
 VERTICALAB_IMG_VERSION=latest
 VERTICALAB_PORT=8889 # Optionally set VERTICALAB_PORT=RANDOM
 VERTICALAB_BIND_ADDRESS=127.0.0.1 # change to 0.0.0.0 if you want to connect from a remote
-PYTHON_VERSION=3.8-slim-buster
+PYTHON_VERSION=3.9-slim-buster
 
 #
 # Vertica demo server


### PR DESCRIPTION
- The upcoming Verticapy  release has some features that depend on python3.9, So I upgraded python version
- To avoid incompatibility between spark containers' python version and verticalab's I also updated spark's Dockerfile.
- https://dlcdn.apache.org/spark/spark-3.3.1/spark-3.3.1-bin-hadoop3.tgz is a broken link so I replaced 3.3.1 with 3.3.2
- install-connector.sh is giving a lot of output we don't really need, so now it will just tell us if the build was a success or not
- Remove sql editor button as it is very limited. I will replace it with grafana