### PR TITLE
Update requirements.txt

### DIFF
--- a/docker-verticapy/requirements.txt
+++ b/docker-verticapy/requirements.txt
@@ -6,4 +6,4 @@ ipywidgets==7.6.5
 voila==0.3.6
 graphviz==0.20.1
 plotly==5.14.1
-verticapy[all]
+verticapy==1.0.0.beta2


### PR DESCRIPTION
- making sure Verticapy v 1.0.0-beta2 is installed as default.