### PR TITLE
Add prometheus

### DIFF
--- a/docker-grafana/docker-compose.yml
+++ b/docker-grafana/docker-compose.yml
@@ -1,10 +1,11 @@
 services:
   # My grafana service
   grafana:
-    image: grafana/grafana-oss:${GF_VERSION:-9.4.3}
+    image: grafana/grafana-enterprise:${GF_VERSION:-9.5.1}
     environment:
-      - GF_INSTALL_PLUGINS=vertica-grafana-datasource ${GF_VERTICA_PLUGIN_VERSION:-2.0.2}
+      - GF_INSTALL_PLUGINS=vertica-grafana-datasource ${GF_VERTICA_PLUGIN_VERSION:-2.1.0}
       - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     container_name: grafana
     ports:

--- a/docker-grafana/provisioning/datasources/sample.yaml
+++ b/docker-grafana/provisioning/datasources/sample.yaml
@@ -52,3 +52,7 @@ datasources:
 #   version: 1
 #   # <bool> allow users to edit datasources from the UI.
    editable: true
+ - name: Prometheus-vertica-ce
+   url: http://prometheus:9090
+   type: prometheus
+   editable: true

--- a/docker-prometheus/docker-compose.yml
+++ b/docker-prometheus/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus:${PROM_VERSION:-v2.48.0}
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "prometheus-data:/prometheus"
+    ports:
+      - 9090:9090
+volumes:
+  prometheus-data:
+networks:
+  default:
+    name: demo
+    driver: bridge
+    external: true

--- a/docker-prometheus/prometheus.yml
+++ b/docker-prometheus/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 10s
+scrape_configs:
+ - job_name: prometheus
+   static_configs:
+    - targets:
+       - prometheus:9090
+ - job_name: 'vertica'
+   scheme: https
+   basic_auth:
+    username: 'dbadmin'
+    password: ''
+   tls_config:
+      insecure_skip_verify: true
+   metrics_path: '/v1/metrics'
+   scrape_interval: 5s
+   static_configs:
+    - targets: ['verticadb:8443']

--- a/etc/VerticaPyLab.conf.default
+++ b/etc/VerticaPyLab.conf.default
@@ -33,17 +33,23 @@ DOCKER_NETWORK=demo
 #
 # Grafana
 #
-GF_VERSION=9.4.3 
+GF_VERSION=9.5.1
 GF_VERTICA_PLUGIN_VERSION=2.1.0
 # Do not change this variable unless you want to run grafana on a diffrent port
 # either as standalone or together with VerticaPyLab(in this case you need to run
-# `make verticapylab-build` to crete a custom image)
+# `make verticapylab-build` to create a custom image)
 GF_PORT=3000
 
 #
 # Spark
 #
 SPARK_VERSION=3.3.2
+
+#
+# Prometheus
+#
+PROM_VERSION=v2.48.0
+PROM_VOLUME=prometheus-data
 
 #
 # Other


### PR DESCRIPTION
We support prometheus metrics in vertica. They are exposed through an http endpoint. 
A prometheus container has been added to scrape that endpoint and allow us to see what's going on in our vertica ce  ontainer without running sql queries. Grafana can also use data collected by prometheus to build nice visuals.
This is the first of a series that will improve prometheus support.