### PR TITLE
Update README.md to reflect the changes in Docker version requirement

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -39,6 +39,8 @@ Install WSL 2.
 3. Click the gear icon on the top right and navigate to the <b>General</b> tab.
 4. Verify that the <b>Use WSL 2 based engine</b> option is checked. If not, check it and click <b>Apply & Restart.</b>
 
+> **_NOTE:_** VerticaPyLab only works with Docker version 18.09 and higher. 
+
 ## Import VerticaPyLab
 
 1. Start Ubuntu from the Start menu.


### PR DESCRIPTION
The "mount" flag was only introduced after v18.09 and upwards. So it is better to provide the this information in the doc. 